### PR TITLE
Resolves issue #45: Missing event ID parameter names no longer lead...

### DIFF
--- a/src/Logfile.Structured/Elements/Event.cs
+++ b/src/Logfile.Structured/Elements/Event.cs
@@ -117,7 +117,7 @@ namespace Logfile.Structured.Elements
                 for (int i = 0; i < eventID.StringArguments.Count(); i++)
                 {
                     if (i > 0) arguments.Append(", ");
-                    var name = eventID.ParameterNames.Count() >= i + 1 ? eventID.ParameterNames.ElementAt(i) : null;
+                    var name = eventID.ParameterNames?.Count() >= i + 1 ? eventID.ParameterNames.ElementAt(i) : null;
                     var value = eventID.StringArguments.ElementAt(i);
                     if (value != null) value = ContentEncoding.Encode(value);
                     if (!string.IsNullOrWhiteSpace(name))

--- a/src/Logfile.Structured/Formatters/EventID.cs
+++ b/src/Logfile.Structured/Formatters/EventID.cs
@@ -84,7 +84,7 @@ namespace Logfile.Structured.Formatters
 			{
 				for (int i = 0; i < eventID.StringArguments.Count(); i++)
 				{
-					var name = eventID.ParameterNames.Count() >= i + 1 ? eventID.ParameterNames.ElementAt(i) : null;
+					var name = eventID.ParameterNames?.Count() >= i + 1 ? eventID.ParameterNames.ElementAt(i) : null;
 					var value = eventID.StringArguments.ElementAt(i);
 					var obj = new JObject();
 					if (!string.IsNullOrWhiteSpace(name))

--- a/tests/Logfile.Structured.SampleApp/Program.cs
+++ b/tests/Logfile.Structured.SampleApp/Program.cs
@@ -83,6 +83,7 @@ namespace Logfile.Structured.SampleApp
 
 			logfile.Warning.Event(TestEvent.One, 1, 2, 3).Log();
 			logfile.Warning.Event(TestEvent.Two).Log();
+			logfile.Warning.Event(TestEvent.Two, "arg").Log();
 
 			// Expected output:
 			// This is the logfile.
@@ -93,6 +94,7 @@ namespace Logfile.Structured.SampleApp
 			// This comes from within an exception object. This is logging without a logger reference.
 			// 1.1 TestEvent.One ... `EventID`=`{"en": [ 1, 1 ], "et": [ "TestEvent", "One" ], "a": [ { "n": "P1", "v": "1" }, { "n": "P2", "v": "2" }, { "v": "3" } ] }`
 			// 1.2 TestEvent.Two
+			// 1.2 TestEvent.Two... `EventID`=`{"en": [ 1, 2 ], "et": [ "TestEvent", "Two" ], "a": [ { "v": "args" } ] }`
 
 			logfile.Warning.Msg(new string('=', 1000)).Log();
 


### PR DESCRIPTION
…to exception and thus not putting out the whole event.